### PR TITLE
Check the current age limit in the config

### DIFF
--- a/app/models/player.py
+++ b/app/models/player.py
@@ -34,7 +34,9 @@ class Region(Enum):
     KR = "KR"
 
 
-def age_filter(days=config.AGE_LIMIT):
+def age_filter(days=None):
+    if days is None:
+        days = config.AGE_LIMIT
     now = timezone.now()
     days_ago = now - timezone.timedelta(days=days)
     return models.Q(modified_at__gte=days_ago)


### PR DESCRIPTION
Previously would set the default value for `days` to `config.AGE_LIMIT` when `age_filter` is first defined. The default value would not change when `config.AGE_LIMIT` was updated.